### PR TITLE
Add Flutter navigation scaffold with splash screen

### DIFF
--- a/lib/calendar_page.dart
+++ b/lib/calendar_page.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class CalendarPage extends StatelessWidget {
+  const CalendarPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: BackButton(onPressed: () => Navigator.pop(context)),
+        title: const Text('Calendar'),
+      ),
+      body: const Center(
+        child: Text('Placeholder for Calendar'),
+      ),
+    );
+  }
+}

--- a/lib/employees_page.dart
+++ b/lib/employees_page.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class EmployeesPage extends StatelessWidget {
+  const EmployeesPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: BackButton(onPressed: () => Navigator.pop(context)),
+        title: const Text('Employees'),
+      ),
+      body: const Center(
+        child: Text('Placeholder for Employees'),
+      ),
+    );
+  }
+}

--- a/lib/estimates_page.dart
+++ b/lib/estimates_page.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class EstimatesPage extends StatelessWidget {
+  const EstimatesPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: BackButton(onPressed: () => Navigator.pop(context)),
+        title: const Text('Estimates'),
+      ),
+      body: const Center(
+        child: Text('Placeholder for Estimates'),
+      ),
+    );
+  }
+}

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Row(
+        children: [
+          Expanded(
+            flex: 1,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                _navButton(context, 'Jobs', '/jobs'),
+                _navButton(context, 'Estimates', '/estimates'),
+                _navButton(context, 'Employees', '/employees'),
+                _navButton(context, 'Inbox', '/inbox'),
+                _navButton(context, 'Leads', '/leads'),
+                _navButton(context, 'Calendar', '/calendar'),
+                _navButton(context, 'Vehicles', '/vehicles'),
+              ],
+            ),
+          ),
+          Expanded(
+            flex: 2,
+            child: Container(
+              color: Colors.grey[300],
+              child: const Center(
+                child: Text('Image Area'),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _navButton(BuildContext context, String title, String route) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: ElevatedButton(
+        onPressed: () => Navigator.pushNamed(context, route),
+        child: Text(title),
+      ),
+    );
+  }
+}

--- a/lib/inbox_page.dart
+++ b/lib/inbox_page.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class InboxPage extends StatelessWidget {
+  const InboxPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: BackButton(onPressed: () => Navigator.pop(context)),
+        title: const Text('Inbox'),
+      ),
+      body: const Center(
+        child: Text('Placeholder for Inbox'),
+      ),
+    );
+  }
+}

--- a/lib/jobs_page.dart
+++ b/lib/jobs_page.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class JobsPage extends StatelessWidget {
+  const JobsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: BackButton(onPressed: () => Navigator.pop(context)),
+        title: const Text('Jobs'),
+      ),
+      body: const Center(
+        child: Text('Placeholder for Jobs'),
+      ),
+    );
+  }
+}

--- a/lib/leads_page.dart
+++ b/lib/leads_page.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class LeadsPage extends StatelessWidget {
+  const LeadsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: BackButton(onPressed: () => Navigator.pop(context)),
+        title: const Text('Leads'),
+      ),
+      body: const Center(
+        child: Text('Placeholder for Leads'),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'splash_screen.dart';
+import 'home_page.dart';
+import 'jobs_page.dart';
+import 'estimates_page.dart';
+import 'employees_page.dart';
+import 'inbox_page.dart';
+import 'leads_page.dart';
+import 'calendar_page.dart';
+import 'vehicles_page.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: "America's Perfect Home",
+      initialRoute: '/',
+      routes: {
+        '/': (context) => const SplashScreen(),
+        '/home': (context) => const HomePage(),
+        '/jobs': (context) => const JobsPage(),
+        '/estimates': (context) => const EstimatesPage(),
+        '/employees': (context) => const EmployeesPage(),
+        '/inbox': (context) => const InboxPage(),
+        '/leads': (context) => const LeadsPage(),
+        '/calendar': (context) => const CalendarPage(),
+        '/vehicles': (context) => const VehiclesPage(),
+      },
+    );
+  }
+}

--- a/lib/splash_screen.dart
+++ b/lib/splash_screen.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class SplashScreen extends StatefulWidget {
+  const SplashScreen({super.key});
+
+  @override
+  State<SplashScreen> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashScreen> {
+  @override
+  void initState() {
+    super.initState();
+    Future.delayed(const Duration(seconds: 3), () {
+      Navigator.pushReplacementNamed(context, '/home');
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('LOGO'),
+      ),
+    );
+  }
+}

--- a/lib/vehicles_page.dart
+++ b/lib/vehicles_page.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class VehiclesPage extends StatelessWidget {
+  const VehiclesPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: BackButton(onPressed: () => Navigator.pop(context)),
+        title: const Text('Vehicles'),
+      ),
+      body: const Center(
+        child: Text('Placeholder for Vehicles'),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,17 @@
+name: americas_perfect_home
+description: A Flutter app navigation scaffold
+publish_to: 'none'
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- scaffold Flutter app with splash screen and named routes
- build home page with vertical navigation and placeholder image
- add placeholder pages for Jobs, Estimates, Employees, Inbox, Leads, Calendar, and Vehicles

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format lib pubspec.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c190ac79888331841b554c9a651828