### PR TITLE
Add job detail tabs and material request workflow

### DIFF
--- a/lib/inbox_page.dart
+++ b/lib/inbox_page.dart
@@ -1,7 +1,28 @@
 import 'package:flutter/material.dart';
+import 'models.dart';
 
-class InboxPage extends StatelessWidget {
+class InboxPage extends StatefulWidget {
   const InboxPage({super.key});
+
+  @override
+  State<InboxPage> createState() => _InboxPageState();
+}
+
+class _InboxPageState extends State<InboxPage> {
+  void _approve(MaterialRequest request) {
+    setState(() {
+      request.job.materials.add(
+        MaterialItem(name: request.materialName, quantity: request.quantity),
+      );
+      materialRequests.remove(request);
+    });
+  }
+
+  void _deny(MaterialRequest request) {
+    setState(() {
+      materialRequests.remove(request);
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -10,9 +31,37 @@ class InboxPage extends StatelessWidget {
         leading: BackButton(onPressed: () => Navigator.pop(context)),
         title: const Text('Inbox'),
       ),
-      body: const Center(
-        child: Text('Placeholder for Inbox'),
-      ),
+      body: materialRequests.isEmpty
+          ? const Center(child: Text('No material requests'))
+          : ListView.builder(
+              itemCount: materialRequests.length,
+              itemBuilder: (context, index) {
+                final request = materialRequests[index];
+                return Card(
+                  margin:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                  child: ListTile(
+                    title: Text(request.materialName),
+                    subtitle: Text(
+                        'Qty: ${request.quantity}\nJob: ${request.job.name}\nBy: ${request.employeeName}\nNote: ${request.note}'),
+                    isThreeLine: true,
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        IconButton(
+                          icon: const Icon(Icons.check),
+                          onPressed: () => _approve(request),
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.close),
+                          onPressed: () => _deny(request),
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
     );
   }
 }

--- a/lib/jobs_page.dart
+++ b/lib/jobs_page.dart
@@ -1,7 +1,12 @@
 import 'package:flutter/material.dart';
+import 'models.dart';
+import 'job_detail_page.dart';
 
 class JobsPage extends StatelessWidget {
-  const JobsPage({super.key});
+  final bool isAdmin;
+  final String employeeName;
+
+  const JobsPage({super.key, this.isAdmin = true, this.employeeName = 'Employee'});
 
   @override
   Widget build(BuildContext context) {
@@ -10,8 +15,31 @@ class JobsPage extends StatelessWidget {
         leading: BackButton(onPressed: () => Navigator.pop(context)),
         title: const Text('Jobs'),
       ),
-      body: const Center(
-        child: Text('Placeholder for Jobs'),
+      body: ListView.builder(
+        itemCount: mockJobs.length,
+        itemBuilder: (context, index) {
+          final job = mockJobs[index];
+          return Card(
+            margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            child: ListTile(
+              title: Text(job.name),
+              subtitle: Text('${job.client}\nStatus: ${job.status}'),
+              isThreeLine: true,
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => JobDetailPage(
+                      job: job,
+                      isAdmin: isAdmin,
+                      employeeName: employeeName,
+                    ),
+                  ),
+                );
+              },
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/material_request_form.dart
+++ b/lib/material_request_form.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'models.dart';
+
+class MaterialRequestForm extends StatefulWidget {
+  final Job job;
+  final String employeeName;
+
+  const MaterialRequestForm({
+    super.key,
+    required this.job,
+    required this.employeeName,
+  });
+
+  @override
+  State<MaterialRequestForm> createState() => _MaterialRequestFormState();
+}
+
+class _MaterialRequestFormState extends State<MaterialRequestForm> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _quantityController = TextEditingController();
+  final _noteController = TextEditingController();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _quantityController.dispose();
+    _noteController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    if (_formKey.currentState!.validate()) {
+      final request = MaterialRequest(
+        job: widget.job,
+        materialName: _nameController.text.trim(),
+        quantity: int.parse(_quantityController.text.trim()),
+        note: _noteController.text.trim(),
+        employeeName: widget.employeeName,
+      );
+      setState(() {
+        materialRequests.add(request);
+      });
+      Navigator.pop(context);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Request Materials'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(labelText: 'Material Name'),
+                validator: (value) =>
+                    value == null || value.isEmpty ? 'Required' : null,
+              ),
+              TextFormField(
+                controller: _quantityController,
+                decoration: const InputDecoration(labelText: 'Quantity'),
+                keyboardType: TextInputType.number,
+                validator: (value) {
+                  if (value == null || value.isEmpty) return 'Required';
+                  return int.tryParse(value) == null ? 'Enter a number' : null;
+                },
+              ),
+              TextFormField(
+                controller: _noteController,
+                decoration: const InputDecoration(labelText: 'Note'),
+                validator: (value) =>
+                    value == null || value.isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: _submit,
+                child: const Text('Submit'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+class MaterialItem {
+  String name;
+  int quantity;
+
+  MaterialItem({required this.name, required this.quantity});
+}
+
+class Job {
+  final int id;
+  String name;
+  String client;
+  double currentCost;
+  double projectedCost;
+  String status;
+  List<MaterialItem> materials;
+  List<String> employees;
+  List<String> timeLogs;
+  List<String> invoices;
+
+  Job({
+    required this.id,
+    required this.name,
+    required this.client,
+    required this.currentCost,
+    required this.projectedCost,
+    required this.status,
+    this.materials = const [],
+    this.employees = const [],
+    this.timeLogs = const [],
+    this.invoices = const [],
+  });
+}
+
+class MaterialRequest {
+  final Job job;
+  final String materialName;
+  final int quantity;
+  final String note;
+  final String employeeName;
+
+  MaterialRequest({
+    required this.job,
+    required this.materialName,
+    required this.quantity,
+    required this.note,
+    required this.employeeName,
+  });
+}
+
+final List<Job> mockJobs = [
+  Job(
+    id: 1,
+    name: 'Kitchen Remodel',
+    client: 'Smith Family',
+    currentCost: 5000,
+    projectedCost: 12000,
+    status: 'In Progress',
+    materials: [MaterialItem(name: 'Wood', quantity: 20)],
+    employees: ['Alice', 'Bob'],
+    timeLogs: ['Logged 8 hours'],
+    invoices: ['Invoice #1'],
+  ),
+  Job(
+    id: 2,
+    name: 'Bathroom Renovation',
+    client: 'Johnson Family',
+    currentCost: 3000,
+    projectedCost: 8000,
+    status: 'Not Started',
+    materials: [MaterialItem(name: 'Tiles', quantity: 100)],
+    employees: ['Charlie'],
+    timeLogs: [],
+    invoices: [],
+  ),
+];
+
+final List<MaterialRequest> materialRequests = [];
+


### PR DESCRIPTION
## Summary
- implement jobs list with navigation to detailed job tabs
- allow admins to manage materials and employees to request materials
- track material requests in inbox with approve/deny actions that update jobs

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1aa87ae988331a344d1cdac9aaffb