### PR TITLE
Flutter mock estimates and templates workflow

### DIFF
--- a/lib/create_estimate_page.dart
+++ b/lib/create_estimate_page.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/material.dart';
+import 'models.dart';
+
+class CreateEstimatePage extends StatefulWidget {
+  const CreateEstimatePage({super.key});
+
+  @override
+  State<CreateEstimatePage> createState() => _CreateEstimatePageState();
+}
+
+class _CreateEstimatePageState extends State<CreateEstimatePage> {
+  EstimateTemplate? selectedTemplate;
+  final TextEditingController titleController = TextEditingController();
+  final TextEditingController clientController = TextEditingController();
+  final TextEditingController amountController = TextEditingController();
+  List<MaterialItem> materials = [];
+  List<MaterialItem> labor = [];
+
+  void _selectTemplate(EstimateTemplate? template) {
+    setState(() {
+      selectedTemplate = template;
+      if (template != null) {
+        titleController.text = template.name;
+        materials = template.materials
+            .map((e) => MaterialItem(name: e.name, quantity: e.quantity))
+            .toList();
+        labor = template.labor
+            .map((e) => MaterialItem(name: e.name, quantity: e.quantity))
+            .toList();
+      } else {
+        materials = [];
+        labor = [];
+      }
+    });
+  }
+
+  void _addItem(List<MaterialItem> list) {
+    final nameController = TextEditingController();
+    final qtyController = TextEditingController();
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Add Item'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: nameController,
+              decoration: const InputDecoration(labelText: 'Name'),
+            ),
+            TextField(
+              controller: qtyController,
+              decoration: const InputDecoration(labelText: 'Quantity'),
+              keyboardType: TextInputType.number,
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              final name = nameController.text.trim();
+              final qty = int.tryParse(qtyController.text.trim()) ?? 0;
+              if (name.isNotEmpty && qty > 0) {
+                setState(() {
+                  list.add(MaterialItem(name: name, quantity: qty));
+                });
+                Navigator.pop(context);
+              }
+            },
+            child: const Text('Add'),
+          )
+        ],
+      ),
+    );
+  }
+
+  void _save({required bool send}) {
+    final id = mockEstimates.isEmpty
+        ? 1
+        : mockEstimates.map((e) => e.id).reduce((a, b) => a > b ? a : b) + 1;
+    final estimate = Estimate(
+      id: id,
+      title: titleController.text,
+      clientName: clientController.text,
+      amount: double.tryParse(amountController.text) ?? 0,
+      materials: List.from(materials),
+      labor: List.from(labor),
+      status: send ? 'Sent' : 'Draft',
+      templateId: selectedTemplate?.id,
+    );
+    mockEstimates.add(estimate);
+    Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Create Estimate'),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          DropdownButton<EstimateTemplate>(
+            value: selectedTemplate,
+            hint: const Text('Select Template'),
+            isExpanded: true,
+            items: [
+              const DropdownMenuItem(
+                value: null,
+                child: Text('Blank'),
+              ),
+              ...mockTemplates.map(
+                (t) => DropdownMenuItem(
+                  value: t,
+                  child: Text(t.name),
+                ),
+              )
+            ],
+            onChanged: _selectTemplate,
+          ),
+          TextField(
+            controller: titleController,
+            decoration: const InputDecoration(labelText: 'Title'),
+          ),
+          TextField(
+            controller: clientController,
+            decoration: const InputDecoration(labelText: 'Client Name'),
+          ),
+          TextField(
+            controller: amountController,
+            decoration: const InputDecoration(labelText: 'Amount'),
+            keyboardType: TextInputType.number,
+          ),
+          const SizedBox(height: 16),
+          const Text('Materials', style: TextStyle(fontWeight: FontWeight.bold)),
+          ...materials
+              .asMap()
+              .entries
+              .map((e) => ListTile(
+                    title: Text('${e.value.name} x${e.value.quantity}'),
+                    trailing: IconButton(
+                      icon: const Icon(Icons.delete),
+                      onPressed: () {
+                        setState(() {
+                          materials.removeAt(e.key);
+                        });
+                      },
+                    ),
+                  )),
+          TextButton(
+            onPressed: () => _addItem(materials),
+            child: const Text('Add Material'),
+          ),
+          const SizedBox(height: 16),
+          const Text('Labor', style: TextStyle(fontWeight: FontWeight.bold)),
+          ...labor
+              .asMap()
+              .entries
+              .map((e) => ListTile(
+                    title: Text('${e.value.name} x${e.value.quantity}'),
+                    trailing: IconButton(
+                      icon: const Icon(Icons.delete),
+                      onPressed: () {
+                        setState(() {
+                          labor.removeAt(e.key);
+                        });
+                      },
+                    ),
+                  )),
+          TextButton(
+            onPressed: () => _addItem(labor),
+            child: const Text('Add Labor'),
+          ),
+          const SizedBox(height: 24),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              ElevatedButton(
+                  onPressed: () => _save(send: false),
+                  child: const Text('Save Draft')),
+              ElevatedButton(
+                  onPressed: () => _save(send: true),
+                  child: const Text('Send to Client')),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/estimate_detail_page.dart
+++ b/lib/estimate_detail_page.dart
@@ -1,0 +1,262 @@
+import 'package:flutter/material.dart';
+import 'models.dart';
+
+class EstimateDetailPage extends StatefulWidget {
+  final Estimate estimate;
+  const EstimateDetailPage({super.key, required this.estimate});
+
+  @override
+  State<EstimateDetailPage> createState() => _EstimateDetailPageState();
+}
+
+class _EstimateDetailPageState extends State<EstimateDetailPage> {
+  late TextEditingController titleController;
+  late TextEditingController clientController;
+  late TextEditingController amountController;
+  late List<MaterialItem> materials;
+  late List<MaterialItem> labor;
+
+  @override
+  void initState() {
+    super.initState();
+    titleController = TextEditingController(text: widget.estimate.title);
+    clientController = TextEditingController(text: widget.estimate.clientName);
+    amountController =
+        TextEditingController(text: widget.estimate.amount.toString());
+    materials = widget.estimate.materials
+        .map((e) => MaterialItem(name: e.name, quantity: e.quantity))
+        .toList();
+    labor = widget.estimate.labor
+        .map((e) => MaterialItem(name: e.name, quantity: e.quantity))
+        .toList();
+  }
+
+  @override
+  void dispose() {
+    titleController.dispose();
+    clientController.dispose();
+    amountController.dispose();
+    super.dispose();
+  }
+
+  void _addItem(List<MaterialItem> list) {
+    final nameController = TextEditingController();
+    final qtyController = TextEditingController();
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Add Item'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: nameController,
+              decoration: const InputDecoration(labelText: 'Name'),
+            ),
+            TextField(
+              controller: qtyController,
+              decoration: const InputDecoration(labelText: 'Quantity'),
+              keyboardType: TextInputType.number,
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              final name = nameController.text.trim();
+              final qty = int.tryParse(qtyController.text.trim()) ?? 0;
+              if (name.isNotEmpty && qty > 0) {
+                setState(() {
+                  list.add(MaterialItem(name: name, quantity: qty));
+                });
+                Navigator.pop(context);
+              }
+            },
+            child: const Text('Add'),
+          )
+        ],
+      ),
+    );
+  }
+
+  void _save() {
+    setState(() {
+      widget.estimate.title = titleController.text;
+      widget.estimate.clientName = clientController.text;
+      widget.estimate.amount =
+          double.tryParse(amountController.text) ?? widget.estimate.amount;
+      widget.estimate.materials = List.from(materials);
+      widget.estimate.labor = List.from(labor);
+    });
+    Navigator.pop(context);
+  }
+
+  void _delete() {
+    mockEstimates.remove(widget.estimate);
+    for (final job in mockJobs) {
+      job.estimates.removeWhere((e) => e.id == widget.estimate.id);
+    }
+    Navigator.pop(context);
+  }
+
+  void _sendToClient() {
+    setState(() => widget.estimate.status = 'Sent');
+  }
+
+  void _approve() {
+    setState(() => widget.estimate.status = 'Accepted');
+  }
+
+  void _reject() {
+    setState(() => widget.estimate.status = 'Rejected');
+  }
+
+  void _convertToJob() {
+    final newJob = Job(
+      id: mockJobs.length + 1,
+      name: widget.estimate.title,
+      client: widget.estimate.clientName,
+      currentCost: 0,
+      projectedCost: widget.estimate.amount,
+      status: 'Not Started',
+      materials: List.from(widget.estimate.materials),
+      estimates: [widget.estimate],
+    );
+    widget.estimate.jobId = newJob.id;
+    mockJobs.add(newJob);
+    Navigator.pop(context);
+  }
+
+  void _attachToJob() {
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Attach to Job'),
+        content: SizedBox(
+          width: double.maxFinite,
+          child: ListView.builder(
+            shrinkWrap: true,
+            itemCount: mockJobs.length,
+            itemBuilder: (context, index) {
+              final job = mockJobs[index];
+              return ListTile(
+                title: Text(job.name),
+                onTap: () {
+                  setState(() {
+                    widget.estimate.jobId = job.id;
+                    job.estimates.add(widget.estimate);
+                    job.materials.addAll(widget.estimate.materials);
+                    job.projectedCost += widget.estimate.amount;
+                  });
+                  Navigator.pop(context);
+                  Navigator.pop(context);
+                },
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final est = widget.estimate;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Estimate ${est.id}'),
+        actions: [
+          IconButton(onPressed: _delete, icon: const Icon(Icons.delete)),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          TextField(
+            controller: titleController,
+            decoration: const InputDecoration(labelText: 'Title'),
+          ),
+          TextField(
+            controller: clientController,
+            decoration: const InputDecoration(labelText: 'Client Name'),
+          ),
+          TextField(
+            controller: amountController,
+            decoration: const InputDecoration(labelText: 'Amount'),
+            keyboardType: TextInputType.number,
+          ),
+          const SizedBox(height: 16),
+          const Text('Materials', style: TextStyle(fontWeight: FontWeight.bold)),
+          ...materials
+              .asMap()
+              .entries
+              .map((e) => ListTile(
+                    title: Text('${e.value.name} x${e.value.quantity}'),
+                    trailing: IconButton(
+                      icon: const Icon(Icons.delete),
+                      onPressed: () {
+                        setState(() {
+                          materials.removeAt(e.key);
+                        });
+                      },
+                    ),
+                  )),
+          TextButton(
+            onPressed: () => _addItem(materials),
+            child: const Text('Add Material'),
+          ),
+          const SizedBox(height: 16),
+          const Text('Labor', style: TextStyle(fontWeight: FontWeight.bold)),
+          ...labor
+              .asMap()
+              .entries
+              .map((e) => ListTile(
+                    title: Text('${e.value.name} x${e.value.quantity}'),
+                    trailing: IconButton(
+                      icon: const Icon(Icons.delete),
+                      onPressed: () {
+                        setState(() {
+                          labor.removeAt(e.key);
+                        });
+                      },
+                    ),
+                  )),
+          TextButton(
+            onPressed: () => _addItem(labor),
+            child: const Text('Add Labor'),
+          ),
+          const SizedBox(height: 24),
+          Text('Status: ${est.status}'),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 8,
+            children: [
+              ElevatedButton(onPressed: _save, child: const Text('Save')),
+              if (est.status == 'Draft' || est.status == 'Rejected')
+                ElevatedButton(
+                    onPressed: _sendToClient, child: const Text('Send to Client')),
+              if (est.status == 'Sent')
+                ElevatedButton(
+                    onPressed: _approve, child: const Text('Mark Accepted')),
+              if (est.status == 'Sent')
+                ElevatedButton(
+                    onPressed: _reject, child: const Text('Mark Rejected')),
+              if (est.status == 'Accepted' && est.jobId == null)
+                ElevatedButton(
+                    onPressed: _convertToJob,
+                    child: const Text('Convert to Job')),
+              if (est.status == 'Accepted' && est.jobId == null)
+                ElevatedButton(
+                    onPressed: _attachToJob,
+                    child: const Text('Attach to Job')),
+            ],
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/estimates_page.dart
+++ b/lib/estimates_page.dart
@@ -1,4 +1,8 @@
 import 'package:flutter/material.dart';
+import 'models.dart';
+import 'create_estimate_page.dart';
+import 'templates_page.dart';
+import 'estimate_detail_page.dart';
 
 class EstimatesPage extends StatelessWidget {
   const EstimatesPage({super.key});
@@ -10,8 +14,193 @@ class EstimatesPage extends StatelessWidget {
         leading: BackButton(onPressed: () => Navigator.pop(context)),
         title: const Text('Estimates'),
       ),
-      body: const Center(
-        child: Text('Placeholder for Estimates'),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const DraftEstimatesPage()),
+                );
+              },
+              child: const Text('View Draft Estimates'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const CreateEstimatePage()),
+                );
+              },
+              child: const Text('Create New Estimate'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const TemplatesPage()),
+                );
+              },
+              child: const Text('Manage Templates'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class DraftEstimatesPage extends StatefulWidget {
+  const DraftEstimatesPage({super.key});
+
+  @override
+  State<DraftEstimatesPage> createState() => _DraftEstimatesPageState();
+}
+
+class _DraftEstimatesPageState extends State<DraftEstimatesPage> {
+  void _deleteEstimate(Estimate estimate) {
+    setState(() {
+      mockEstimates.remove(estimate);
+    });
+  }
+
+  void _sendToClient(Estimate estimate) {
+    setState(() => estimate.status = 'Sent');
+  }
+
+  void _approve(Estimate estimate) {
+    setState(() => estimate.status = 'Accepted');
+  }
+
+  void _reject(Estimate estimate) {
+    setState(() => estimate.status = 'Rejected');
+  }
+
+  void _convertToJob(Estimate estimate) {
+    final newJob = Job(
+      id: mockJobs.length + 1,
+      name: estimate.title,
+      client: estimate.clientName,
+      currentCost: 0,
+      projectedCost: estimate.amount,
+      status: 'Not Started',
+      materials: List.from(estimate.materials),
+      estimates: [estimate],
+    );
+    estimate.jobId = newJob.id;
+    mockJobs.add(newJob);
+    setState(() {});
+  }
+
+  void _attachToJob(Estimate estimate) {
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Attach to Job'),
+        content: SizedBox(
+          width: double.maxFinite,
+          child: ListView.builder(
+            shrinkWrap: true,
+            itemCount: mockJobs.length,
+            itemBuilder: (context, index) {
+              final job = mockJobs[index];
+              return ListTile(
+                title: Text(job.name),
+                onTap: () {
+                  setState(() {
+                    estimate.jobId = job.id;
+                    job.estimates.add(estimate);
+                    job.materials.addAll(estimate.materials);
+                    job.projectedCost += estimate.amount;
+                  });
+                  Navigator.pop(context);
+                },
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final drafts = mockEstimates.where((e) => e.jobId == null).toList();
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Draft Estimates'),
+      ),
+      body: ListView.builder(
+        itemCount: drafts.length,
+        itemBuilder: (context, index) {
+          final estimate = drafts[index];
+          return Card(
+            margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            child: ListTile(
+              title: Text('${estimate.title} (ID: ${estimate.id})'),
+              subtitle: Text('${estimate.clientName}\nStatus: ${estimate.status}'),
+              isThreeLine: true,
+              trailing: PopupMenuButton<String>(
+                onSelected: (value) {
+                  switch (value) {
+                    case 'edit':
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (_) => EstimateDetailPage(estimate: estimate)),
+                      ).then((_) => setState(() {}));
+                      break;
+                    case 'delete':
+                      _deleteEstimate(estimate);
+                      break;
+                    case 'send':
+                      _sendToClient(estimate);
+                      break;
+                    case 'approve':
+                      _approve(estimate);
+                      break;
+                    case 'reject':
+                      _reject(estimate);
+                      break;
+                    case 'convert':
+                      _convertToJob(estimate);
+                      break;
+                    case 'attach':
+                      _attachToJob(estimate);
+                      break;
+                  }
+                },
+                itemBuilder: (context) {
+                  final items = <PopupMenuEntry<String>>[
+                    const PopupMenuItem(value: 'edit', child: Text('Edit')),
+                    const PopupMenuItem(value: 'delete', child: Text('Delete')),
+                  ];
+                  if (estimate.status == 'Draft' || estimate.status == 'Rejected') {
+                    items.add(
+                        const PopupMenuItem(value: 'send', child: Text('Send to Client')));
+                  }
+                  if (estimate.status == 'Sent') {
+                    items.add(
+                        const PopupMenuItem(value: 'approve', child: Text('Mark Accepted')));
+                    items.add(
+                        const PopupMenuItem(value: 'reject', child: Text('Mark Rejected')));
+                  }
+                  if (estimate.status == 'Accepted') {
+                    items.add(
+                        const PopupMenuItem(value: 'convert', child: Text('Convert to Job')));
+                    items.add(const PopupMenuItem(
+                        value: 'attach', child: Text('Attach to Job')));
+                  }
+                  return items;
+                },
+              ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/job_detail_page.dart
+++ b/lib/job_detail_page.dart
@@ -207,12 +207,6 @@ class _JobDetailPageState extends State<JobDetailPage>
                     ? '\nAmount: \$${estimate.amount.toStringAsFixed(2)}'
                     : '')),
             isThreeLine: widget.isAdmin,
-            trailing: widget.isAdmin && estimate.status != 'Approved'
-                ? TextButton(
-                    onPressed: () => _approveEstimate(estimate),
-                    child: const Text('Approve'),
-                  )
-                : null,
           ),
         );
       },
@@ -231,62 +225,6 @@ class _JobDetailPageState extends State<JobDetailPage>
               child: const Icon(Icons.add),
             );
     }
-    if (_tabController.index == 4 && widget.isAdmin) {
-      return FloatingActionButton(
-        onPressed: _attachEstimate,
-        child: const Icon(Icons.attach_file),
-      );
-    }
     return null;
-  }
-
-  void _attachEstimate() {
-    showDialog(
-      context: context,
-      builder: (context) {
-        return AlertDialog(
-          title: const Text('Attach Estimate'),
-          content: SizedBox(
-            width: double.maxFinite,
-            child: ListView.builder(
-              shrinkWrap: true,
-              itemCount: availableEstimates.length,
-              itemBuilder: (context, index) {
-                final estimate = availableEstimates[index];
-                return ListTile(
-                  title: Text(estimate.title),
-                  subtitle:
-                      Text('Amount: \$${estimate.amount.toStringAsFixed(2)}'),
-                  onTap: () {
-                    setState(() {
-                      widget.job.estimates.add(estimate);
-                      availableEstimates.removeAt(index);
-                    });
-                    Navigator.pop(context);
-                  },
-                );
-              },
-            ),
-          ),
-        );
-      },
-    );
-  }
-
-  void _approveEstimate(Estimate estimate) {
-    setState(() {
-      estimate.status = 'Approved';
-      for (final item in estimate.materials) {
-        final existingIndex = widget.job.materials
-            .indexWhere((m) => m.name == item.name);
-        if (existingIndex >= 0) {
-          widget.job.materials[existingIndex].quantity += item.quantity;
-        } else {
-          widget.job.materials
-              .add(MaterialItem(name: item.name, quantity: item.quantity));
-        }
-      }
-      widget.job.projectedCost += estimate.amount;
-    });
   }
 }

--- a/lib/jobs_page.dart
+++ b/lib/jobs_page.dart
@@ -2,12 +2,17 @@ import 'package:flutter/material.dart';
 import 'models.dart';
 import 'job_detail_page.dart';
 
-class JobsPage extends StatelessWidget {
+class JobsPage extends StatefulWidget {
   final bool isAdmin;
   final String employeeName;
 
   const JobsPage({super.key, this.isAdmin = true, this.employeeName = 'Employee'});
 
+  @override
+  State<JobsPage> createState() => _JobsPageState();
+}
+
+class _JobsPageState extends State<JobsPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -32,11 +37,11 @@ class JobsPage extends StatelessWidget {
                   MaterialPageRoute(
                     builder: (_) => JobDetailPage(
                       job: job,
-                      isAdmin: isAdmin,
-                      employeeName: employeeName,
+                      isAdmin: widget.isAdmin,
+                      employeeName: widget.employeeName,
                     ),
                   ),
-                );
+                ).then((_) => setState(() {}));
               },
             ),
           );

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -7,19 +7,45 @@ class MaterialItem {
   MaterialItem({required this.name, required this.quantity});
 }
 
+/// Represents an estimate template that can be used as a starting point
+/// when creating new estimates.
+class EstimateTemplate {
+  final int id;
+  String name;
+  List<MaterialItem> materials;
+  List<MaterialItem> labor;
+
+  EstimateTemplate({
+    required this.id,
+    required this.name,
+    this.materials = const [],
+    this.labor = const [],
+  });
+}
+
+/// Model representing an estimate in the system. Estimates can be linked to a
+/// job once approved. Until then they remain in draft form.
 class Estimate {
   final int id;
   String title;
+  String clientName;
   double amount;
-  String status;
+  String status; // Draft, Sent, Accepted, Rejected
   List<MaterialItem> materials;
+  List<MaterialItem> labor;
+  int? templateId;
+  int? jobId; // populated when converted or attached to a job
 
   Estimate({
     required this.id,
     required this.title,
+    required this.clientName,
     required this.amount,
-    this.status = 'Pending',
+    this.status = 'Draft',
     this.materials = const [],
+    this.labor = const [],
+    this.templateId,
+    this.jobId,
   });
 }
 
@@ -65,6 +91,51 @@ class MaterialRequest {
   });
 }
 
+/// Pre-populated templates and estimates used throughout the demo
+final List<EstimateTemplate> mockTemplates = [
+  EstimateTemplate(
+    id: 1,
+    name: 'Basic Kitchen',
+    materials: [MaterialItem(name: 'Wood', quantity: 10)],
+  ),
+];
+
+/// Global list of all estimates (drafts and those linked to jobs)
+final List<Estimate> mockEstimates = [
+  Estimate(
+    id: 101,
+    title: 'Original Estimate',
+    clientName: 'Smith Family',
+    amount: 12000,
+    status: 'Accepted',
+    materials: [MaterialItem(name: 'Wood', quantity: 20)],
+    jobId: 1,
+  ),
+  Estimate(
+    id: 201,
+    title: 'Initial Estimate',
+    clientName: 'Johnson Family',
+    amount: 8000,
+    status: 'Draft',
+    materials: [MaterialItem(name: 'Tiles', quantity: 100)],
+    jobId: 2,
+  ),
+  Estimate(
+    id: 301,
+    title: 'Cabinet Upgrade',
+    clientName: 'Williams',
+    amount: 2000,
+    materials: [MaterialItem(name: 'Cabinet', quantity: 5)],
+  ),
+  Estimate(
+    id: 302,
+    title: 'Lighting Addition',
+    clientName: 'Williams',
+    amount: 1500,
+    materials: [MaterialItem(name: 'LED Light', quantity: 20)],
+  ),
+];
+
 final List<Job> mockJobs = [
   Job(
     id: 1,
@@ -76,15 +147,7 @@ final List<Job> mockJobs = [
     materials: [MaterialItem(name: 'Wood', quantity: 20)],
     employees: ['Alice', 'Bob'],
     timeLogs: ['Logged 8 hours'],
-    estimates: [
-      Estimate(
-        id: 101,
-        title: 'Original Estimate',
-        amount: 12000,
-        status: 'Approved',
-        materials: [MaterialItem(name: 'Wood', quantity: 20)],
-      ),
-    ],
+    estimates: [mockEstimates[0]],
   ),
   Job(
     id: 2,
@@ -96,32 +159,9 @@ final List<Job> mockJobs = [
     materials: [MaterialItem(name: 'Tiles', quantity: 100)],
     employees: ['Charlie'],
     timeLogs: [],
-    estimates: [
-      Estimate(
-        id: 201,
-        title: 'Initial Estimate',
-        amount: 8000,
-        status: 'Pending',
-        materials: [MaterialItem(name: 'Tiles', quantity: 100)],
-      ),
-    ],
+    estimates: [mockEstimates[1]],
   ),
 ];
 
 final List<MaterialRequest> materialRequests = [];
-
-final List<Estimate> availableEstimates = [
-  Estimate(
-    id: 301,
-    title: 'Cabinet Upgrade',
-    amount: 2000,
-    materials: [MaterialItem(name: 'Cabinet', quantity: 5)],
-  ),
-  Estimate(
-    id: 302,
-    title: 'Lighting Addition',
-    amount: 1500,
-    materials: [MaterialItem(name: 'LED Light', quantity: 20)],
-  ),
-];
 

--- a/lib/templates_page.dart
+++ b/lib/templates_page.dart
@@ -1,0 +1,171 @@
+import 'package:flutter/material.dart';
+import 'models.dart';
+
+class TemplatesPage extends StatefulWidget {
+  const TemplatesPage({super.key});
+
+  @override
+  State<TemplatesPage> createState() => _TemplatesPageState();
+}
+
+class _TemplatesPageState extends State<TemplatesPage> {
+  void _openTemplateForm({EstimateTemplate? template, int? index}) {
+    final nameController = TextEditingController(text: template?.name ?? '');
+    List<MaterialItem> materials =
+        template != null ? List.from(template.materials) : [];
+    List<MaterialItem> labor = template != null ? List.from(template.labor) : [];
+
+    void addItem(List<MaterialItem> list) {
+      final n = TextEditingController();
+      final q = TextEditingController();
+      showDialog(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: const Text('Add Item'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(controller: n, decoration: const InputDecoration(labelText: 'Name')),
+              TextField(controller: q, decoration: const InputDecoration(labelText: 'Quantity'), keyboardType: TextInputType.number),
+            ],
+          ),
+          actions: [
+            TextButton(onPressed: () => Navigator.pop(context), child: const Text('Cancel')),
+            ElevatedButton(
+                onPressed: () {
+                  final name = n.text.trim();
+                  final qty = int.tryParse(q.text.trim()) ?? 0;
+                  if (name.isNotEmpty && qty > 0) {
+                    setState(() {
+                      list.add(MaterialItem(name: name, quantity: qty));
+                    });
+                    Navigator.pop(context);
+                  }
+                },
+                child: const Text('Add'))
+          ],
+        ),
+      );
+    }
+
+    showDialog(
+      context: context,
+      builder: (_) => StatefulBuilder(builder: (context, setDialog) {
+        return AlertDialog(
+          title: Text(template == null ? 'New Template' : 'Edit Template'),
+          content: SizedBox(
+            width: double.maxFinite,
+            child: ListView(
+              shrinkWrap: true,
+              children: [
+                TextField(
+                  controller: nameController,
+                  decoration: const InputDecoration(labelText: 'Name'),
+                ),
+                const SizedBox(height: 8),
+                const Text('Materials', style: TextStyle(fontWeight: FontWeight.bold)),
+                ...materials.asMap().entries.map(
+                      (e) => ListTile(
+                        title: Text('${e.value.name} x${e.value.quantity}'),
+                        trailing: IconButton(
+                          icon: const Icon(Icons.delete),
+                          onPressed: () {
+                            setDialog(() => materials.removeAt(e.key));
+                          },
+                        ),
+                      ),
+                    ),
+                TextButton(
+                    onPressed: () => addItem(materials),
+                    child: const Text('Add Material')),
+                const SizedBox(height: 8),
+                const Text('Labor', style: TextStyle(fontWeight: FontWeight.bold)),
+                ...labor.asMap().entries.map(
+                      (e) => ListTile(
+                        title: Text('${e.value.name} x${e.value.quantity}'),
+                        trailing: IconButton(
+                          icon: const Icon(Icons.delete),
+                          onPressed: () {
+                            setDialog(() => labor.removeAt(e.key));
+                          },
+                        ),
+                      ),
+                    ),
+                TextButton(
+                    onPressed: () => addItem(labor),
+                    child: const Text('Add Labor')),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('Cancel')),
+            ElevatedButton(
+                onPressed: () {
+                  final name = nameController.text.trim();
+                  if (name.isEmpty) return;
+                  setState(() {
+                    final tmpl = EstimateTemplate(
+                        id: template?.id ?? (mockTemplates.isEmpty
+                            ? 1
+                            : mockTemplates
+                                    .map((e) => e.id)
+                                    .reduce((a, b) => a > b ? a : b) +
+                                1),
+                        name: name,
+                        materials: materials,
+                        labor: labor);
+                    if (index != null) {
+                      mockTemplates[index] = tmpl;
+                    } else {
+                      mockTemplates.add(tmpl);
+                    }
+                  });
+                  Navigator.pop(context);
+                },
+                child: const Text('Save'))
+          ],
+        );
+      }),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Templates'),
+      ),
+      body: ListView.builder(
+        itemCount: mockTemplates.length,
+        itemBuilder: (context, index) {
+          final template = mockTemplates[index];
+          return Card(
+            margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            child: ListTile(
+              title: Text(template.name),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                      icon: const Icon(Icons.edit),
+                      onPressed: () => _openTemplateForm(template: template, index: index)),
+                  IconButton(
+                      icon: const Icon(Icons.delete),
+                      onPressed: () {
+                        setState(() => mockTemplates.removeAt(index));
+                      })
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _openTemplateForm(),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add in-memory models for estimates and templates
- implement Estimates page with draft list, create flow, and template management
- allow approved estimates to convert to jobs or attach to existing jobs and update job detail view

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b2747f8483318fb539f79d38c7ca