### PR TITLE
Add labor hours and employee assignments to estimates

### DIFF
--- a/lib/models.dart
+++ b/lib/models.dart
@@ -1,11 +1,12 @@
-import 'package:flutter/material.dart';
+import 'models/material_item.dart';
+import 'models/estimate.dart';
+import 'models/labor_item.dart';
+import 'models/employee.dart';
 
-class MaterialItem {
-  String name;
-  int quantity;
-
-  MaterialItem({required this.name, required this.quantity});
-}
+export 'models/material_item.dart';
+export 'models/estimate.dart';
+export 'models/labor_item.dart';
+export 'models/employee.dart';
 
 /// Represents an estimate template that can be used as a starting point
 /// when creating new estimates.
@@ -13,39 +14,13 @@ class EstimateTemplate {
   final int id;
   String name;
   List<MaterialItem> materials;
-  List<MaterialItem> labor;
+  List<LaborItem> labor;
 
   EstimateTemplate({
     required this.id,
     required this.name,
     this.materials = const [],
     this.labor = const [],
-  });
-}
-
-/// Model representing an estimate in the system. Estimates can be linked to a
-/// job once approved. Until then they remain in draft form.
-class Estimate {
-  final int id;
-  String title;
-  String clientName;
-  double amount;
-  String status; // Draft, Sent, Accepted, Rejected
-  List<MaterialItem> materials;
-  List<MaterialItem> labor;
-  int? templateId;
-  int? jobId; // populated when converted or attached to a job
-
-  Estimate({
-    required this.id,
-    required this.title,
-    required this.clientName,
-    required this.amount,
-    this.status = 'Draft',
-    this.materials = const [],
-    this.labor = const [],
-    this.templateId,
-    this.jobId,
   });
 }
 
@@ -106,34 +81,34 @@ final List<Estimate> mockEstimates = [
     id: 101,
     title: 'Original Estimate',
     clientName: 'Smith Family',
-    amount: 12000,
     status: 'Accepted',
+    materialsCost: 12000,
     materials: [MaterialItem(name: 'Wood', quantity: 20)],
     jobId: 1,
-  ),
+  )..updateTotal(),
   Estimate(
     id: 201,
     title: 'Initial Estimate',
     clientName: 'Johnson Family',
-    amount: 8000,
     status: 'Draft',
+    materialsCost: 8000,
     materials: [MaterialItem(name: 'Tiles', quantity: 100)],
     jobId: 2,
-  ),
+  )..updateTotal(),
   Estimate(
     id: 301,
     title: 'Cabinet Upgrade',
     clientName: 'Williams',
-    amount: 2000,
+    materialsCost: 2000,
     materials: [MaterialItem(name: 'Cabinet', quantity: 5)],
-  ),
+  )..updateTotal(),
   Estimate(
     id: 302,
     title: 'Lighting Addition',
     clientName: 'Williams',
-    amount: 1500,
+    materialsCost: 1500,
     materials: [MaterialItem(name: 'LED Light', quantity: 20)],
-  ),
+  )..updateTotal(),
 ];
 
 final List<Job> mockJobs = [
@@ -164,4 +139,3 @@ final List<Job> mockJobs = [
 ];
 
 final List<MaterialRequest> materialRequests = [];
-

--- a/lib/models/employee.dart
+++ b/lib/models/employee.dart
@@ -1,0 +1,12 @@
+class Employee {
+  final int id;
+  final String name;
+  final double hourlyRate;
+
+  Employee({required this.id, required this.name, required this.hourlyRate});
+}
+
+final List<Employee> mockEmployees = [
+  Employee(id: 1, name: 'Bob', hourlyRate: 50),
+  Employee(id: 2, name: 'Susan', hourlyRate: 65),
+];

--- a/lib/models/estimate.dart
+++ b/lib/models/estimate.dart
@@ -1,0 +1,34 @@
+import 'labor_item.dart';
+import 'material_item.dart';
+
+class Estimate {
+  final int id;
+  String title;
+  String clientName;
+  String status; // Draft, Sent, Accepted, Rejected
+  List<MaterialItem> materials;
+  List<LaborItem> labor;
+  int? templateId;
+  int? jobId; // populated when converted or attached to a job
+  double materialsCost;
+  double amount; // total cost including labor
+
+  Estimate({
+    required this.id,
+    required this.title,
+    required this.clientName,
+    this.status = 'Draft',
+    this.materials = const [],
+    this.labor = const [],
+    this.templateId,
+    this.jobId,
+    this.materialsCost = 0,
+  }) : amount = materialsCost;
+
+  double get laborCost =>
+      labor.fold(0.0, (total, item) => total + item.cost);
+
+  void updateTotal() {
+    amount = materialsCost + laborCost;
+  }
+}

--- a/lib/models/labor_item.dart
+++ b/lib/models/labor_item.dart
@@ -1,0 +1,24 @@
+import 'employee.dart';
+
+class LaborItem {
+  String role;
+  double hours;
+  int? employeeId;
+
+  LaborItem({required this.role, required this.hours, this.employeeId});
+
+  Employee? get employee {
+    if (employeeId == null) return null;
+    try {
+      return mockEmployees.firstWhere((e) => e.id == employeeId);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  double get rate => employee?.hourlyRate ?? 0;
+
+  double get cost => rate * hours;
+
+  String get employeeName => employee?.name ?? 'Employee TBD';
+}

--- a/lib/models/material_item.dart
+++ b/lib/models/material_item.dart
@@ -1,0 +1,6 @@
+class MaterialItem {
+  String name;
+  int quantity;
+
+  MaterialItem({required this.name, required this.quantity});
+}


### PR DESCRIPTION
## Summary
- Introduce Employee and LaborItem models with mock employee data and automatic cost calculation
- Extend Estimate model to track material and labor subtotals and compute totals
- Upgrade Create Estimate page with labor entry form, employee dropdown, and dynamic cost totals

## Testing
- `dart format lib/models.dart lib/models/*.dart lib/create_estimate_page.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c231843ac08331a47e4a856e1bd2fe