### PR TITLE
feat: show estimated vs actual materials and labor

### DIFF
--- a/lib/models.dart
+++ b/lib/models.dart
@@ -32,7 +32,7 @@ class Job {
   double projectedCost;
   String status;
   List<MaterialItem> materials;
-  List<String> employees;
+  List<LaborItem> employees;
   List<String> timeLogs;
   List<Estimate> estimates;
 
@@ -120,7 +120,10 @@ final List<Job> mockJobs = [
     projectedCost: 12000,
     status: 'In Progress',
     materials: [MaterialItem(name: 'Wood', quantity: 20)],
-    employees: ['Alice', 'Bob'],
+    employees: [
+      LaborItem(role: 'Alice', estimatedHours: 40),
+      LaborItem(role: 'Bob', estimatedHours: 35),
+    ],
     timeLogs: ['Logged 8 hours'],
     estimates: [mockEstimates[0]],
   ),
@@ -132,7 +135,7 @@ final List<Job> mockJobs = [
     projectedCost: 8000,
     status: 'Not Started',
     materials: [MaterialItem(name: 'Tiles', quantity: 100)],
-    employees: ['Charlie'],
+    employees: [LaborItem(role: 'Charlie', estimatedHours: 20)],
     timeLogs: [],
     estimates: [mockEstimates[1]],
   ),

--- a/lib/models/labor_item.dart
+++ b/lib/models/labor_item.dart
@@ -1,11 +1,17 @@
 class LaborItem {
   final String role;
-  final double hours;
+  final double estimatedHours;
+  double actualHours;
   final String? employeeId;
 
   LaborItem({
     required this.role,
-    required this.hours,
+    double? estimatedHours,
+    this.actualHours = 0,
+    double? hours,
     this.employeeId,
-  });
+  }) : estimatedHours = estimatedHours ?? hours ?? 0;
+
+  /// Backwards compatible getter for older code using `hours`.
+  double get hours => estimatedHours;
 }

--- a/lib/models/material_item.dart
+++ b/lib/models/material_item.dart
@@ -1,6 +1,15 @@
 class MaterialItem {
-  String name;
-  int quantity;
+  final String name;
+  final double estimatedQuantity;
+  double actualQuantity;
 
-  MaterialItem({required this.name, required this.quantity});
+  MaterialItem({
+    required this.name,
+    double? estimatedQuantity,
+    this.actualQuantity = 0,
+    int? quantity,
+  }) : estimatedQuantity = estimatedQuantity ?? quantity?.toDouble() ?? 0;
+
+  /// Backwards compatible getter for older code using `quantity`.
+  int get quantity => estimatedQuantity.toInt();
 }


### PR DESCRIPTION
## Summary
- track estimated and actual quantities for materials and labor
- consolidate materials and employees overview with editable actual fields
- update job model and mock data for new labor structure

## Testing
- `flutter --version` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c23c917f788331a77b34393ed3040e