### PR TITLE
Add logo splash screen and app icon configuration

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,22 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_native_splash: ^2.4.0
+  flutter_launcher_icons: ^0.13.1
 
 flutter:
   uses-material-design: true
+  assets:
+    - assets/logo.webp
+
+flutter_native_splash:
+  color: "#FFFFFF"
+  image: assets/logo.webp
+  android: true
+  ios: true
+
+flutter_icons:
+  android: true
+  ios: true
+  image_path: assets/logo.webp
+  remove_alpha_ios: true


### PR DESCRIPTION
## Summary
- configure flutter_native_splash with logo asset and white background
- configure flutter_launcher_icons to use logo for Android and iOS
- register logo asset in flutter section

## Testing
- `flutter pub get` *(fails: building flutter tool stuck after resolving dependencies)*
- `flutter pub run flutter_native_splash:create` *(fails: no output, process did not complete)*
- `flutter pub run flutter_launcher_icons:main` *(fails: process stalled after fetching dependencies)*
- `flutter test` *(fails: process stalled after fetching dependencies)*
- `flutter build ios --no-codesign` *(fails: process stalled after fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c398cb2d5483319cd4bb25dba017bc