### PR TITLE
Update navigation background to customer blue

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -10,17 +10,20 @@ class HomePage extends StatelessWidget {
         children: [
           Expanded(
             flex: 1,
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                _navButton(context, 'Jobs', '/jobs'),
-                _navButton(context, 'Estimates', '/estimates'),
-                _navButton(context, 'Employees', '/employees'),
-                _navButton(context, 'Inbox', '/inbox'),
-                _navButton(context, 'Leads', '/leads'),
-                _navButton(context, 'Calendar', '/calendar'),
-                _navButton(context, 'Vehicles', '/vehicles'),
-              ],
+            child: Container(
+              color: const Color(0xFF2E5265),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  _navButton(context, 'Jobs', '/jobs'),
+                  _navButton(context, 'Estimates', '/estimates'),
+                  _navButton(context, 'Employees', '/employees'),
+                  _navButton(context, 'Inbox', '/inbox'),
+                  _navButton(context, 'Leads', '/leads'),
+                  _navButton(context, 'Calendar', '/calendar'),
+                  _navButton(context, 'Vehicles', '/vehicles'),
+                ],
+              ),
             ),
           ),
           Expanded(


### PR DESCRIPTION
## Summary
- adjust home page navigation panel to use customer brand blue `#2E5265`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3ad1dd76083319c9a856a91f4206e