### PR TITLE
Display company logo in navigation panel

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -29,9 +29,12 @@ class HomePage extends StatelessWidget {
           Expanded(
             flex: 2,
             child: Container(
-              color: Colors.grey[300],
-              child: const Center(
-                child: Text('Image Area'),
+              color: Colors.white,
+              child: Center(
+                child: Image.asset(
+                  'assets/logo.png',
+                  fit: BoxFit.contain,
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
## Summary
- Show the company logo in the right two-thirds of the home page navigation row
- Keep left third of navigation in brand blue and buttons untouched

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3af48cf80833186a33cd84f665d5d