### PR TITLE
Add iOS launch screen with centered logo

### DIFF
--- a/ios/Runner/Assets.xcassets/LaunchLogo.imageset/Contents.json
+++ b/ios/Runner/Assets.xcassets/LaunchLogo.imageset/Contents.json
@@ -1,0 +1,8 @@
+{
+  "images" : [
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/ios/Runner/Base.lproj/LaunchScreen.storyboard
+++ b/ios/Runner/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" useAutolayout="YES" launchScreen="YES" initialViewController="UIViewController">
+    <scenes>
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="BYZ-38-t0r" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <subviews>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" image="LaunchLogo" id="logoView"/>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="logoView" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="centerX"/>
+                            <constraint firstItem="logoView" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="centerY"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="LaunchLogo"/>
+    </resources>
+</document>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -22,6 +22,8 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+        <key>UILaunchStoryboardName</key>
+        <string>LaunchScreen</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
## Summary
- add LaunchScreen storyboard with centered logo and white background
- configure Info.plist to use LaunchScreen
- add empty LaunchLogo asset set placeholder

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a3b9eff483319af98c27e28e6254