### PR TITLE
Remove rounded styling from content area

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -103,20 +103,10 @@ class NavigationPage extends StatelessWidget {
                 ),
               ),
               const SizedBox(width: 32),
-              Expanded(
+              const Expanded(
                 child: Container(
-                  decoration: BoxDecoration(
-                    color: Colors.white,
-                    borderRadius: BorderRadius.circular(32),
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.black.withOpacity(0.04),
-                        blurRadius: 20,
-                        offset: const Offset(0, 10),
-                      ),
-                    ],
-                  ),
-                  child: const Center(
+                  color: Colors.white,
+                  child: Center(
                     child: Text(
                       'Image Area',
                       style: TextStyle(


### PR DESCRIPTION
## Summary
- remove the decorative BoxDecoration from the right-hand content panel so it renders as a flat white surface

## Testing
- `flutter analyze` *(fails: `flutter` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a7ac3ed48331b070065a6ffddc0b