### PR TITLE
Adjust content area background layout

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -102,10 +102,9 @@ class NavigationPage extends StatelessWidget {
                   ],
                 ),
               ),
-              const SizedBox(width: 32),
               Expanded(
                 child: Container(
-                  color: Colors.white,
+                  color: const Color(0xFFF3F4F8),
                   child: Center(
                     child: Text(
                       'Image Area',


### PR DESCRIPTION
## Summary
- remove the spacer between the navigation rail and the main content so the background fills edge to edge
- set the content area container to the scaffold background color to keep the hover appearance of the navigation sidebar

## Testing
- flutter analyze *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9aa5c4ac08331ada5fc9044e9a6cf