### PR TITLE
Add logo asset to navigation layout

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -64,7 +64,7 @@ class NavigationPage extends StatelessWidget {
                 padding:
                     const EdgeInsets.symmetric(vertical: 24, horizontal: 12),
                 decoration: BoxDecoration(
-                  color: Colors.white,
+                  color: const Color(0xFF2F5061),
                   borderRadius: BorderRadius.circular(28),
                   boxShadow: [
                     BoxShadow(
@@ -83,7 +83,7 @@ class NavigationPage extends StatelessWidget {
                       style: TextStyle(
                         fontSize: 18,
                         fontWeight: FontWeight.bold,
-                        color: Color(0xFF2E3A59),
+                        color: Colors.white,
                       ),
                     ),
                     const SizedBox(height: 24),
@@ -106,12 +106,11 @@ class NavigationPage extends StatelessWidget {
                 child: Container(
                   color: const Color(0xFFF3F4F8),
                   child: Center(
-                    child: Text(
-                      'Image Area',
-                      style: TextStyle(
-                        fontSize: 24,
-                        fontWeight: FontWeight.w600,
-                        color: Color(0xFF2E3A59),
+                    child: Padding(
+                      padding: const EdgeInsets.all(24),
+                      child: Image.asset(
+                        'assets/logo.png',
+                        fit: BoxFit.contain,
                       ),
                     ),
                   ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,3 +17,5 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  assets:
+    - assets/logo.png


### PR DESCRIPTION
## Summary
- update the navigation panel background to use the brand color and keep text legible
- replace the placeholder content with a centered logo image asset
- register the logo asset in the pubspec so it can be bundled with the app

## Testing
- flutter test *(fails: `flutter` command is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb6610abfc83318c944dd1bb60be48