### PR TITLE
Move estimate status badges to bottom-right

### DIFF
--- a/lib/screens/estimates/estimate_detail_page.dart
+++ b/lib/screens/estimates/estimate_detail_page.dart
@@ -56,41 +56,17 @@ class EstimateDetailPage extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: <Widget>[
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    Text(
-                      estimate.title,
-                      style: const TextStyle(
-                        fontSize: 20,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
-                      'Estimate #${estimate.estimateNumber}',
-                      style: TextStyle(color: Colors.grey.shade800),
-                    ),
-                  ],
-                ),
-                Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-                  decoration: BoxDecoration(
-                    color: _statusColor(estimate.status).withOpacity(0.12),
-                    borderRadius: BorderRadius.circular(16),
-                  ),
-                  child: Text(
-                    _statusLabel(estimate.status),
-                    style: TextStyle(
-                      color: _statusColor(estimate.status),
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                ),
-              ],
+            Text(
+              estimate.title,
+              style: const TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Estimate #${estimate.estimateNumber}',
+              style: TextStyle(color: Colors.grey.shade800),
             ),
             const SizedBox(height: 16),
             Row(
@@ -123,6 +99,24 @@ class EstimateDetailPage extends StatelessWidget {
                 ],
               ),
             ],
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerRight,
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                decoration: BoxDecoration(
+                  color: _statusColor(estimate.status).withOpacity(0.12),
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: Text(
+                  _statusLabel(estimate.status),
+                  style: TextStyle(
+                    color: _statusColor(estimate.status),
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            ),
           ],
         ),
       ),

--- a/lib/screens/estimates/estimates_page.dart
+++ b/lib/screens/estimates/estimates_page.dart
@@ -143,55 +143,53 @@ class _EstimatesPageState extends State<EstimatesPage> {
                             elevation: 1,
                             child: Padding(
                               padding: const EdgeInsets.all(16),
-                              child: Row(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
                                 children: <Widget>[
-                                  Expanded(
-                                    child: Column(
-                                      crossAxisAlignment: CrossAxisAlignment.start,
-                                      children: <Widget>[
-                                        Text(
-                                          estimate.title,
-                                          style: const TextStyle(
-                                            fontSize: 18,
-                                            fontWeight: FontWeight.w700,
-                                          ),
-                                        ),
-                                        const SizedBox(height: 6),
-                                        Text(
-                                          estimate.customerName,
-                                          style: TextStyle(
-                                            color: Colors.grey.shade800,
-                                          ),
-                                        ),
-                                        const SizedBox(height: 12),
-                                        Row(
-                                          children: <Widget>[
-                                            _buildStatusChip(estimate.status),
-                                            const SizedBox(width: 12),
-                                            Text(
-                                              _formatDate(estimate.createdAt),
-                                              style: TextStyle(color: Colors.grey.shade700),
-                                            ),
-                                          ],
-                                        ),
-                                      ],
+                                  Text(
+                                    estimate.title,
+                                    style: const TextStyle(
+                                      fontSize: 18,
+                                      fontWeight: FontWeight.w700,
                                     ),
                                   ),
-                                  Column(
-                                    crossAxisAlignment: CrossAxisAlignment.end,
+                                  const SizedBox(height: 6),
+                                  Text(
+                                    estimate.customerName,
+                                    style: TextStyle(
+                                      color: Colors.grey.shade800,
+                                    ),
+                                  ),
+                                  const SizedBox(height: 12),
+                                  Row(
                                     children: <Widget>[
-                                      const Text(
-                                        'Total',
-                                        style: TextStyle(fontWeight: FontWeight.w600),
-                                      ),
                                       Text(
-                                        '\$${estimate.total.toStringAsFixed(2)}',
-                                        style: const TextStyle(
-                                          fontSize: 18,
-                                          fontWeight: FontWeight.bold,
-                                        ),
+                                        _formatDate(estimate.createdAt),
+                                        style: TextStyle(color: Colors.grey.shade700),
+                                      ),
+                                      const Spacer(),
+                                      Column(
+                                        crossAxisAlignment: CrossAxisAlignment.end,
+                                        children: <Widget>[
+                                          const Text(
+                                            'Total',
+                                            style: TextStyle(fontWeight: FontWeight.w600),
+                                          ),
+                                          Text(
+                                            '\$${estimate.total.toStringAsFixed(2)}',
+                                            style: const TextStyle(
+                                              fontSize: 18,
+                                              fontWeight: FontWeight.bold,
+                                            ),
+                                          ),
+                                        ],
                                       ),
                                     ],
+                                  ),
+                                  const SizedBox(height: 12),
+                                  Align(
+                                    alignment: Alignment.centerRight,
+                                    child: _buildStatusChip(estimate.status),
                                   ),
                                 ],
                               ),


### PR DESCRIPTION
## Summary
- rework the estimate detail overview card layout to place the status pill at the bottom-right without altering its styling
- update estimate list cards to use a column layout with bottom-right aligned status chips to prevent horizontal overflow
- keep existing text, date, and total details aligned while removing the previous row-based spacing

## Testing
- flutter format lib/screens/estimates/estimate_detail_page.dart lib/screens/estimates/estimates_page.dart *(fails: command not found: flutter)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692277e550708331aca1e556fc1dfe69)